### PR TITLE
Intuitive name for mongo collection logs

### DIFF
--- a/R/set_logging.R
+++ b/R/set_logging.R
@@ -189,7 +189,7 @@ set_logging <- function(r_console  = TRUE,
     } else {
 
       assign("log_db",
-             mongolite::mongo("demo", url = readLines(db_url_file)[1]),
+             mongolite::mongo("shiny_logs", url = readLines(db_url_file)[1]),
              envir = parent.frame()
              )
 


### PR DESCRIPTION
Changes the name of the collection where the logs will be inserted to a more intuitive name.